### PR TITLE
Adds COVERAGE macro to Makefile

### DIFF
--- a/templates/linux-gnu.mk
+++ b/templates/linux-gnu.mk
@@ -55,6 +55,9 @@ FFLAGS += $(FFLAGS_DEBUG)
 else ifneq ($(TEST),)
 CFLAGS += $(CFLAGS_TEST)
 FFLAGS += $(FFLAGS_TEST)
+else ifneq ($(COVERAGE),)
+FFLAGS += --coverage
+LDFLAGS += --coverage
 else
 CFLAGS += $(CFLAGS_OPT)
 FFLAGS += $(FFLAGS_OPT)

--- a/templates/ncrc-gnu.mk
+++ b/templates/ncrc-gnu.mk
@@ -51,6 +51,9 @@ FFLAGS += $(FFLAGS_DEBUG)
 else ifneq ($(TEST),)
 CFLAGS += $(CFLAGS_TEST)
 FFLAGS += $(FFLAGS_TEST)
+else ifneq ($(COVERAGE),)
+FFLAGS += --coverage
+LDFLAGS += --coverage
 else
 CFLAGS += $(CFLAGS_OPT)
 FFLAGS += $(FFLAGS_OPT)


### PR DESCRIPTION
Description:
- Adds command line macro COVERAGE to be used in place of REPRO, DEBUG,
  and TEST. This turns on the same instrumentation used by profilers but
  that can then be processed to assess code coverage (e.g. using lcov).
- Only tested using the ncrc-gnu.mk template.

To use:
  make COVERAGE=1 ...
  aprun -n 4 ...
  lcov -c -d <build_dir> -o lcov.info

If lcov is not available, it can be cloned from https://github.com/linux-test-project/lcov.git .

Credit goes to @angus-g for inspiration and initial implementation.