### PR TITLE
Workaround for gfortran not adding -D__APPLE__

### DIFF
--- a/templates/macOS-gnu8-mpich3.mk
+++ b/templates/macOS-gnu8-mpich3.mk
@@ -1,4 +1,4 @@
-# Template for the GNU Compiler on macOS 
+# Template for the GNU Compiler on macOS
 # Tested on macOS Mojave (version 10.14.2), with gnu 8.2 and mpich 3.3
 #
 # Typical use with mkmf
@@ -81,11 +81,16 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
-# Get number of CPUs 
+# Get number of CPUs
 #MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
 MAKEFLAGS += --jobs=$(shell sysctl -n hw.ncpu)
+
 # Macro for Fortran preprocessor
 FPPFLAGS := $(INCLUDES)
+# Add -D__APPLE__ for Fortran if on OSX (i.e. Darwin)
+ifeq ($(shell uname -s),Darwin)
+FPPFLAGS += -D__APPLE__
+endif
 # Fortran Compiler flags for the NetCDF library
 FPPFLAGS += $(shell nf-config --fflags)
 # Fortran Compiler flags for the MPICH MPI library

--- a/templates/osx-gnu.mk
+++ b/templates/osx-gnu.mk
@@ -4,7 +4,7 @@
 # mkmf -t osx-gnu.mk -c"-Duse_libMPI -Duse_netCDF" path_names /usr/local/include
 
 ############
-# Commands Macors
+# Commands Macros
 FC = mpif90
 CC = mpicc
 CXX = mpicxx
@@ -76,10 +76,17 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+# Get number of CPUs
 MAKEFLAGS += --jobs=$(shell sysctl -n hw.ncpu)
 
 # Macro for Fortran preprocessor
 FPPFLAGS := $(INCLUDES)
+
+# Add -D__APPLE__ for Fortran if on OSX (i.e. Darwin)
+ifeq ($(shell uname -s),Darwin)
+FPPFLAGS += -D__APPLE__
+endif
+
 # Fortran Compiler flags for the NetCDF library
 FPPFLAGS += $(shell nf-config --fflags)
 


### PR DESCRIPTION
Gfortran on Mac OS X does not add the __APPLE__ macro.  Updated the two Mac OS X templates to add this macro definition to the the Fortran preprocessor flags.