### PR TITLE
26 escape.git.version.string

### DIFF
--- a/bin/mkmf
+++ b/bin/mkmf
@@ -38,7 +38,7 @@ sub ensureTrailingSlash {
    local $/ = '/'; chomp @_[0]; @_[0] .= '/';
 }
 
-my $version = '19.3.0';
+my $version = '19.3.1';
 
 # initialize variables: use getopts for these
 GetOptions("abspath|a=s" => \$opt_a,
@@ -142,7 +142,7 @@ if ( $opt_c ) {
 }
 
 if ( $opt_g ) {
-  $opt_c .= ' -D_FILE_VERSION="`git-version-string $<`"';
+  $opt_c .= ' -D_FILE_VERSION=\"`git-version-string $<`\"';
 }
 
 &print_formatted_list("CPPDEFS = $opt_c") if $opt_c;

--- a/t/t003-mkmf.sh
+++ b/t/t003-mkmf.sh
@@ -112,7 +112,7 @@ teardown() {
    run mkmf -g
    [ "$status" -eq 0 ]
    [ -e Makefile ]
-   regexString='^CPPDEFS =  -D_FILE_VERSION="`git-version-string $<`"$'
+   regexString='^CPPDEFS =  -D_FILE_VERSION=\\"`git-version-string $<`\\"$'
    run grep -q "${regexString}" Makefile
    [ "$status" -eq 0 ]
 }

--- a/templates/macOS-gnu8-mpich3.mk
+++ b/templates/macOS-gnu8-mpich3.mk
@@ -1,4 +1,4 @@
-# Template for the GNU Compiler on macOS 
+# Template for the GNU Compiler on macOS
 # Tested on macOS Mojave (version 10.14.2), with gnu 8.2 and mpich 3.3
 #
 # Typical use with mkmf
@@ -81,11 +81,16 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
-# Get number of CPUs 
+# Get number of CPUs
 #MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
 MAKEFLAGS += --jobs=$(shell sysctl -n hw.ncpu)
+
 # Macro for Fortran preprocessor
 FPPFLAGS := $(INCLUDES)
+# Add -D__APPLE__ for Fortran if on OSX (i.e. Darwin)
+ifeq ($(shell uname -s),Darwin)
+FPPFLAGS += -D__APPLE__
+endif
 # Fortran Compiler flags for the NetCDF library
 FPPFLAGS += $(shell nf-config --fflags)
 # Fortran Compiler flags for the MPICH MPI library

--- a/templates/osx-gnu.mk
+++ b/templates/osx-gnu.mk
@@ -4,7 +4,7 @@
 # mkmf -t osx-gnu.mk -c"-Duse_libMPI -Duse_netCDF" path_names /usr/local/include
 
 ############
-# Commands Macors
+# Commands Macros
 FC = mpif90
 CC = mpicc
 CXX = mpicxx
@@ -76,10 +76,17 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+# Get number of CPUs
 MAKEFLAGS += --jobs=$(shell sysctl -n hw.ncpu)
 
 # Macro for Fortran preprocessor
 FPPFLAGS := $(INCLUDES)
+
+# Add -D__APPLE__ for Fortran if on OSX (i.e. Darwin)
+ifeq ($(shell uname -s),Darwin)
+FPPFLAGS += -D__APPLE__
+endif
+
 # Fortran Compiler flags for the NetCDF library
 FPPFLAGS += $(shell nf-config --fflags)
 


### PR DESCRIPTION
Escape the quotes in the call to `git-version-string` in `mkmf`.

Update `mkmf` version number.

fixes #26.