### PR TITLE
Switch Intel ISA/SSE flag to xsse2

### DIFF
--- a/templates/linux-intel.mk
+++ b/templates/linux-intel.mk
@@ -49,7 +49,7 @@ NETCDF =             # If value is '3' and CPPDEFS contains
 INCLUDES =           # A list of -I Include directories to be added to the
                      # the compile command.
 
-SSE = -msse2         # The SSE options to be used to compile.  If blank,
+SSE = -xsse2         # The SSE options to be used to compile.  If blank,
                      # than use the default SSE settings for the host.
                      # Current default is to use SSE2.
 

--- a/templates/nccs-intel.mk
+++ b/templates/nccs-intel.mk
@@ -49,7 +49,7 @@ NETCDF =             # If value is '3' and CPPDEFS contains
 INCLUDES =           # A list of -I Include directories to be added to the
                      # the compile command.
 
-SSE = -msse2         # The SSE options to be used to compile.  If blank,
+SSE = -xsse2         # The SSE options to be used to compile.  If blank,
                      # than use the default SSE settings for the host.
                      # Current default is to use SSE2.
 

--- a/templates/ncrc-intel.mk
+++ b/templates/ncrc-intel.mk
@@ -49,7 +49,7 @@ NETCDF =             # If value is '3' and CPPDEFS contains
 INCLUDES =           # A list of -I Include directories to be added to the
                      # the compile command.
 
-ISA = -msse2         # The Intel Instruction Set Archetecture (ISA) compile
+ISA = -xsse2         # The Intel Instruction Set Archetecture (ISA) compile
                      # option to use.  If blank, than use the default SSE
                      # settings for the host.  Current default is to use SSE2.
 


### PR DESCRIPTION
The intel ISA option -xsse2 is more restrictive than -msse2 on the ncrc site, allowing different Intel compiler version to reproduce each other.