### PR TITLE
Revert backslash escapes to git-version-string output

### DIFF
--- a/bin/mkmf
+++ b/bin/mkmf
@@ -38,7 +38,7 @@ sub ensureTrailingSlash {
    local $/ = '/'; chomp @_[0]; @_[0] .= '/';
 }
 
-my $version = '19.3.1';
+my $version = '19.3.0';
 
 # initialize variables: use getopts for these
 GetOptions("abspath|a=s" => \$opt_a,
@@ -142,7 +142,7 @@ if ( $opt_c ) {
 }
 
 if ( $opt_g ) {
-  $opt_c .= ' -D_FILE_VERSION=\"`git-version-string $<`\"';
+  $opt_c .= ' -D_FILE_VERSION="`git-version-string $<`"';
 }
 
 &print_formatted_list("CPPDEFS = $opt_c") if $opt_c;

--- a/bin/mkmf
+++ b/bin/mkmf
@@ -38,7 +38,7 @@ sub ensureTrailingSlash {
    local $/ = '/'; chomp @_[0]; @_[0] .= '/';
 }
 
-my $version = '19.3.0';
+my $version = '19.3.2';
 
 # initialize variables: use getopts for these
 GetOptions("abspath|a=s" => \$opt_a,

--- a/t/t003-mkmf.sh
+++ b/t/t003-mkmf.sh
@@ -112,7 +112,7 @@ teardown() {
    run mkmf -g
    [ "$status" -eq 0 ]
    [ -e Makefile ]
-   regexString='^CPPDEFS =  -D_FILE_VERSION=\\"`git-version-string $<`\\"$'
+   regexString='^CPPDEFS =  -D_FILE_VERSION="`git-version-string $<`"$'
    run grep -q "${regexString}" Makefile
    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Reverts the recent update that escaped the quotes in the call to `git-version-string` in `mkmf`.

Also updates the `mkmf` version number.

Resolves #33 