### PR TITLE
Added a missing comment character in ncrc-pgi.mk

### DIFF
--- a/templates/ncrc-pgi.mk
+++ b/templates/ncrc-pgi.mk
@@ -177,7 +177,7 @@ FFLAGS += $(FFLAGS_COVERAGE) $(PROF_DIR)
 LDFLAGS += $(LDFLAGS_COVERAGE) $(PROF_DIR)
 endif
 
-These Algebra libraries Add solution to more complex vector matrix model equations
+# These Algebra libraries Add solution to more complex vector matrix model equations
 LIBS += -llapack -lblas
 LDFLAGS += $(LIBS)
 


### PR DESCRIPTION
- NOAA-GFDL/mkmf#29 add a comment with a missing "#" that broke ncrc-pgi.mk