### PR TITLE
Checks syntax of templates

### DIFF
--- a/t/t004-templates.sh
+++ b/t/t004-templates.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+setup() {
+   binDir=$(readlink -f ${BATS_TEST_DIRNAME}/../bin)
+   templateDir=$(readlink -f ${BATS_TEST_DIRNAME}/../templates)
+   testDir=$(mktemp -d ${BATS_TEST_DIRNAME}/${BATS_TEST_NAME}.XXXXXXXX)
+   export PATH=${binDir}:${PATH}
+   cd ${testDir}
+}
+
+teardown() {
+   rm -rf ${testDir}
+}
+
+helper() {
+   run mkmf -t ${templateDir}/"$1"
+   run make .DEFAULT
+   echo "status = ${status}"
+   echo "output = ${output}"
+   [ "$status" -eq 0 ]
+}
+
+@test "template linux-gnu.mk" {
+   helper linux-gnu.mk
+}
+
+@test "template linux-intel.mk" {
+   helper linux-intel.mk
+}
+
+@test "template linux-ubuntu-trusty-gnu.mk" {
+   helper linux-ubuntu-trusty-gnu.mk
+}
+
+@test "template linux-ubuntu-xenial-gnu.mk" {
+   helper linux-ubuntu-xenial-gnu.mk
+}
+
+@test "template macOS-gnu8-mpich3.mk" {
+   helper macOS-gnu8-mpich3.mk
+}
+
+@test "template nccs-intel.mk" {
+   helper nccs-intel.mk
+}
+
+@test "template ncrc-cray.mk" {
+   helper ncrc-cray.mk
+}
+
+@test "template ncrc-gnu.mk" {
+   helper ncrc-gnu.mk
+}
+
+@test "template ncrc-intel.mk" {
+   helper ncrc-intel.mk
+}
+
+@test "template ncrc-pgi.mk" {
+   helper ncrc-pgi.mk
+}
+
+@test "template osx-gnu.mk" {
+   helper osx-gnu.mk
+}
+
+@test "template theia-intel.mk" {
+   helper theia-intel.mk
+}
+
+@test "template triton-gnu.mk" {
+   helper triton-gnu.mk
+}


### PR DESCRIPTION
- To detect syntax problems, such as NOAA-GFDL/mkmf#37, test004 checks that `make` can read each
  template without error.
- Note that this build fails because of a syntax error in ncrc-pgi.mk This PR will pass only after NOAA-GFDL/mkmf#37 is merged.