### PR TITLE
Submodule parsing support; hashing fix

### DIFF
--- a/bin/mkmf
+++ b/bin/mkmf
@@ -369,14 +369,20 @@ sub scanfile_for_keywords {
    print "Scanning file $file of object $object ...\n" if $opt_v;
    open FILE, $file or die "\aERROR opening file $file of object $object: $!\n";
    foreach $line ( <FILE> ) {
-      if ( $line =~ /^\s*module\s+(\w*)/ix ) {
+      if ( $line =~ /^\s*module\s+((?!subroutine|function|procedure)\w*)/ix ) {
          if ( $1 ) {
             my $module = lc $1;
-            if ( $obj_of_module{$module} && $module ne "procedure" ) {
+            if ( $obj_of_module{$module} ) {
                die "\a\nAMBIGUOUS: Module $module is associated with $file as well as $actual_source_of{$obj_of_module{$module}}.\n";
             }
             $obj_of_module{$module} = $object;
          }
+      }
+      if ( $line =~ /^\s*submodule\s+\((\s*\w*\s*)\)\s+(\w*)/ix ) {
+         # Submodules depend on the parent module, but not vice versa
+         #   $1: parent module name
+         #   $2: submodule name
+         $modules_used_by{$object} .= ' ' . lc $1 if $1;
       }
       if ( $line =~ /^\s*use\s*(\w*)/ix ) {
          $modules_used_by{$object} .= ' ' . lc $1 if $1;


### PR DESCRIPTION
This patch adds support for identifying submodules and tagging the
parent module as their dependency.

Expressions as `submodule (some_mod) some_submod` will tag the object
file of `some_mod` as a dependency of the source file of `some_submod`.

---

This patch also modifies the module regexp to reject any of the
following:

- module procedure
- module subroutine
- module function

The latter two are used when working with submodules.  The first is
typically used for generic interfaces.

Previously the `procedure` exception was applied to the consistency
check, but it may have inadvertently been adding a module named
`procedure` to the hashes.  This was probably not causing any errors,
but was probably nonetheless not the desired behavior.

This change prevents any of the subprogram keywords from being added to
the hashes.