### PR TITLE
GCC 10+ FFLAGS requires -fallow-argument-mismatch

### DIFF
--- a/templates/ncrc-gcc.mk
+++ b/templates/ncrc-gcc.mk
@@ -81,7 +81,7 @@ FPPFLAGS := $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fcray-pointer -fdefault-real-8 -fdefault-double-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS := -fcray-pointer -fdefault-real-8 -fdefault-double-8 -Waliasing -ffree-line-length-none -fno-range-check -fallow-argument-mismatch
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O2 -fno-expensive-optimizations


### PR DESCRIPTION
closes #46 

This option is needed due to MPI, not the FMS code.

https://gcc.gnu.org/gcc-10/changes.html

Mismatches between actual and dummy argument lists in a single file are now rejected with an error. Use the new option -fallow-argument-mismatch to turn these errors into warnings; this option is implied with -std=legacy. -Wargument-mismatch has been removed.