### PR TITLE
Like the other C5 templates, intel-classic requires -DHAVE_GETTID

### DIFF
--- a/templates/ncrc5-intel-classic.mk
+++ b/templates/ncrc5-intel-classic.mk
@@ -81,7 +81,7 @@ endif
 CPPDEFS += -Duse_netCDF
 
 # Additional Preprocessor Macros needed due to  Autotools and CMake
-CPPDEFS += -DHAVE_SCHED_GETAFFINITY
+CPPDEFS += -DHAVE_SCHED_GETAFFINITY -DHAVE_GETTID
 
 # Macro for Fortran preprocessor
 FPPFLAGS := -fpp -Wp,-w $(INCLUDES)


### PR DESCRIPTION
be added to the CPPDEFS. Otherwise, compiles fail:

```
.../src/FMS/affinity/affinity.c(51): error #172: external/internal linkage conflict with previous declaration at line 34 of "/usr/include/bits/unistd_ext.h"
  static pid_t gettid(void
```

#42 