### PR TITLE
Like the other C5 templates, nvhpc requires -DHAVE_GETTID

### DIFF
--- a/templates/ncrc-nvhpc.mk
+++ b/templates/ncrc-nvhpc.mk
@@ -81,7 +81,7 @@ endif
 CPPDEFS += -Duse_netCDF
 
 # Additional Preprocessor Macros needed due to  Autotools and CMake
-CPPDEFS += -DHAVE_SCHED_GETAFFINITY
+CPPDEFS += -DHAVE_SCHED_GETAFFINITY -DHAVE_GETTID
 
 # Macro for Fortran preprocessor
 FPPFLAGS := $(INCLUDES)


### PR DESCRIPTION
#42

Otherwise, this compile error results:

```
.../src/FMS/affinity/affinity.c", line 51: error: external/internal linkage conflict with previous declaration at line 34 of "/usr/include/bits/unistd_ext.h"
  static pid_t gettid(void)
               ^
```