### PR TITLE
Add macro for standards compliance flag

### DIFF
--- a/templates/ncrc4-intel.mk
+++ b/templates/ncrc4-intel.mk
@@ -55,6 +55,9 @@ ISA = -xsse2         # The Intel Instruction Set Archetecture (ISA) compile
 
 COVERAGE =           # Add the code coverage compile options.
 
+STANDARD =           # Issue warnings for the given Fortran standard (f90, f95, f03, f08, f18)
+                     # Implies VERBOSE for output
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -100,6 +103,7 @@ FFLAGS_OPENMP = -qopenmp
 FFLAGS_OVERRIDE_LIMITS = -qoverride-limits
 FFLAGS_VERBOSE = -v -V -what -warn all
 FFLAGS_COVERAGE = -prof-gen=srcpos
+FFLAGS_STANDARD = -stand $(STANDARD)
 
 # Macro for C preprocessor
 CPPFLAGS := -D__IFC $(INCLUDES)
@@ -161,6 +165,11 @@ endif
 
 ifdef NO_OVERRIDE_LIMITS
 FFLAGS += $(FFLAGS_OVERRIDE_LIMITS)
+endif
+
+ifdef STANDARD
+FFLAGS += $(FFLAGS_STANDARD)
+VERBOSE = 1
 endif
 
 ifdef VERBOSE

--- a/templates/ncrc5-intel-classic.mk
+++ b/templates/ncrc5-intel-classic.mk
@@ -56,6 +56,9 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+STANDARD =           # Issue warnings for the given Fortran standard (f90, f95, f03, f08, f18)
+                     # Implies VERBOSE for warning output
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -112,6 +115,7 @@ FFLAGS_OPENMP = -qopenmp
 FFLAGS_OVERRIDE_LIMITS = -qoverride-limits
 FFLAGS_VERBOSE = -v -V -what -warn all -qopt-report-phase=vec -qopt-report=2
 FFLAGS_COVERAGE = -prof-gen=srcpos
+FFLAGS_STANDARD = -stand $(STANDARD)
 
 # Macro for C preprocessor
 CPPFLAGS := -D__IFC $(INCLUDES)
@@ -170,6 +174,11 @@ ifdef NO_OVERRIDE_LIMITS
 FFLAGS += $(FFLAGS_OVERRIDE_LIMITS)
 endif
 
+ifdef STANDARD
+FFLAGS += $(FFLAGS_STANDARD)
+VERBOSE = 1
+endif
+
 ifdef VERBOSE
 CFLAGS += $(CFLAGS_VERBOSE)
 FFLAGS += $(FFLAGS_VERBOSE)
@@ -189,6 +198,7 @@ CFLAGS += $(CFLAGS_COVERAGE) $(PROF_DIR)
 FFLAGS += $(FFLAGS_COVERAGE) $(PROF_DIR)
 LDFLAGS += $(LDFLAGS_COVERAGE) $(PROF_DIR)
 endif
+
 
 LDFLAGS += $(LIBS)
 

--- a/templates/ncrc5-intel-oneapi.mk
+++ b/templates/ncrc5-intel-oneapi.mk
@@ -56,6 +56,9 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+STANDARD =           # Issue warnings for the given Fortran standard (f90, f95, f03, f08, f18)
+                     # Implies VERBOSE for output
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -112,6 +115,7 @@ FFLAGS_OPENMP = -qopenmp
 FFLAGS_OVERRIDE_LIMITS = -qoverride-limits
 FFLAGS_VERBOSE = -v -V -what -warn all -qopt-report-phase=vec -qopt-report=2
 FFLAGS_COVERAGE = -prof-gen=srcpos
+FFLAGS_STANDARD = -stand $(STANDARD)
 
 # Macro for C preprocessor
 CPPFLAGS := -D__IFC $(INCLUDES)
@@ -168,6 +172,11 @@ endif
 
 ifdef NO_OVERRIDE_LIMITS
 FFLAGS += $(FFLAGS_OVERRIDE_LIMITS)
+endif
+
+ifdef STANDARD
+FFLAGS += $(FFLAGS_STANDARD)
+VERBOSE = 1
 endif
 
 ifdef VERBOSE

--- a/templates/ncrc5-intel.mk
+++ b/templates/ncrc5-intel.mk
@@ -56,6 +56,9 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+STANDARD =           # Issue warnings for the given Fortran standard (f90, f95, f03, f08, f18)
+                     # Implies VERBOSE for output
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -112,6 +115,7 @@ FFLAGS_OPENMP = -qopenmp
 FFLAGS_OVERRIDE_LIMITS = -qoverride-limits
 FFLAGS_VERBOSE = -v -V -what -warn all -qopt-report-phase=vec -qopt-report=2
 FFLAGS_COVERAGE = -prof-gen=srcpos
+FFLAGS_STANDARD = -stand $(STANDARD)
 
 # Macro for C preprocessor
 CPPFLAGS := -D__IFC $(INCLUDES)
@@ -168,6 +172,11 @@ endif
 
 ifdef NO_OVERRIDE_LIMITS
 FFLAGS += $(FFLAGS_OVERRIDE_LIMITS)
+endif
+
+ifdef STANDARD
+FFLAGS += $(FFLAGS_STANDARD)
+VERBOSE = 1
 endif
 
 ifdef VERBOSE


### PR DESCRIPTION
turns on fortran standards compliance warnings for whichever standard is set at build time (ie. `make STANDARD=f08`)