### PR TITLE
Submodule with no spacing

### DIFF
--- a/bin/mkmf
+++ b/bin/mkmf
@@ -378,7 +378,7 @@ sub scanfile_for_keywords {
             $obj_of_module{$module} = $object;
          }
       }
-      if ( $line =~ /submodule\((.*?)\) (.*)/) {
+      if ( $line =~ /^\s*submodule\s*+\((\s*\w*\s*)\)\s+(\w*)/ix) {
          # Submodules depend on the parent module, but not vice versa
          #   $1: parent module name
          #   $2: submodule name

--- a/bin/mkmf
+++ b/bin/mkmf
@@ -378,7 +378,7 @@ sub scanfile_for_keywords {
             $obj_of_module{$module} = $object;
          }
       }
-      if ( $line =~ /^\s*submodule\s+\((\s*\w*\s*)\)\s+(\w*)/ix ) {
+      if ( $line =~ /submodule\((.*?)\) (.*)/) {
          # Submodules depend on the parent module, but not vice versa
          #   $1: parent module name
          #   $2: submodule name


### PR DESCRIPTION
The current submodule line was not capturing the following case "submodule(A) B". Added a * to allow for no spacing. 