### PR TITLE
Update nccs-intel.mk

### DIFF
--- a/templates/nccs-intel.mk
+++ b/templates/nccs-intel.mk
@@ -6,9 +6,9 @@
 ############
 # Commands Macros
 ############
-FC = mpiifort
-CC = mpiicc
-LD = mpiifort
+FC = mpifort
+CC = mpicc
+LD = mpifort
 
 #######################
 # Build target macros
@@ -49,9 +49,9 @@ NETCDF =             # If value is '3' and CPPDEFS contains
 INCLUDES =           # A list of -I Include directories to be added to the
                      # the compile command.
 
-SSE = -xsse2         # The SSE options to be used to compile.  If blank,
-                     # than use the default SSE settings for the host.
-                     # Current default is to use SSE2.
+SSE = -march=core-avx2  # The SSE options to be used to compile.  If blank,
+                        # than use the default SSE settings for the host.
+                        # Current default is to use SSE2.
 
 COVERAGE =           # Add the code coverage compile options.
 


### PR DESCRIPTION
This PR updates templates/nccs-intel.mk only.

This template was [introduced](https://github.com/NOAA-GFDL/mkmf/pull/20) by @aerorahul to build at NASA's NCCS. Since its introduction, NCCS has started to move from [intel to AMD chips](https://www.nccs.nasa.gov/nccs-users/SCU17-announcement).

2 changes are proposed:
1. Switch to `mpifort` (Why? see: [The Intel 2023 compiler does not currently work with GEOS. Intel is aware of the issue and we will update it as soon as a fix is available.](https://www.nccs.nasa.gov/nccs-users/SCU17-announcement); NCCS primarily supports GEOS applications.
2. Change `SSE` flag for AMD (that @mathomp4 uses for GEOS applications).