### PR TITLE
Adds a static option for linking to the hpcme 23 and 24 templates

### DIFF
--- a/templates/hpcme-intel23.mk
+++ b/templates/hpcme-intel23.mk
@@ -42,6 +42,8 @@ NO_OVERRIDE_LIMITS = # If non-blank, do not use the -qoverride-limits
                      # compiler option.  Default behavior is to compile
                      # with -qoverride-limits.
 
+STATIC =             # If non-blank do a static build
+
 NETCDF =             # If value is '3' and CPPDEFS contains
                      # '-Duse_netCDF', then the additional cpp macro
                      # '-Duse_LARGEFILE' is added to the CPPDEFS macro.
@@ -191,6 +193,10 @@ LDFLAGS += $(LDFLAGS_COVERAGE) $(PROF_DIR)
 endif
 
 LDFLAGS += $(LIBS)
+
+ifdef STATIC
+  LDFLAGS += -static
+endif
 
 #---------------------------------------------------------------------------
 # you should never need to change any lines below.

--- a/templates/hpcme-intel24.mk
+++ b/templates/hpcme-intel24.mk
@@ -42,6 +42,8 @@ NO_OVERRIDE_LIMITS = # If non-blank, do not use the -qoverride-limits
                      # compiler option.  Default behavior is to compile
                      # with -qoverride-limits.
 
+STATIC =             # If non-blank do a static build
+
 NETCDF =             # If value is '3' and CPPDEFS contains
                      # '-Duse_netCDF', then the additional cpp macro
                      # '-Duse_LARGEFILE' is added to the CPPDEFS macro.
@@ -191,6 +193,10 @@ LDFLAGS += $(LDFLAGS_COVERAGE) $(PROF_DIR)
 endif
 
 LDFLAGS += $(LIBS)
+
+ifdef STATIC
+  LDFLAGS += -static
+endif
 
 #---------------------------------------------------------------------------
 # you should never need to change any lines below.


### PR DESCRIPTION
This adds an option to create static executables when running make for hpcme-2023 and hpcme-2024 templates