### PR TITLE
Adds an option to override the real precision to r4

### DIFF
--- a/templates/hpcme-intel21.mk
+++ b/templates/hpcme-intel21.mk
@@ -80,10 +80,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/hpcme-intel21.mk
+++ b/templates/hpcme-intel21.mk
@@ -56,6 +56,8 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -77,6 +79,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -89,7 +98,7 @@ FPPFLAGS := -fpp -Wp,-w $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -sox -traceback
 
 # Set the ISA (vectorization) as user defined or based on the target
 ifdef ISA

--- a/templates/hpcme-intel23.mk
+++ b/templates/hpcme-intel23.mk
@@ -82,10 +82,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/hpcme-intel23.mk
+++ b/templates/hpcme-intel23.mk
@@ -58,6 +58,8 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -79,6 +81,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -91,7 +100,7 @@ FPPFLAGS := -fpp -Wp,-w $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -sox -traceback
 
 # Set the ISA (vectorization) as user defined or based on the target
 ifdef ISA

--- a/templates/hpcme-intel24.mk
+++ b/templates/hpcme-intel24.mk
@@ -82,10 +82,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/hpcme-intel24.mk
+++ b/templates/hpcme-intel24.mk
@@ -58,6 +58,8 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -79,6 +81,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -91,7 +100,7 @@ FPPFLAGS := -fpp -Wp,-w $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -sox -traceback
 
 # Set the ISA (vectorization) as user defined or based on the target
 ifdef ISA

--- a/templates/linux-gnu.mk
+++ b/templates/linux-gnu.mk
@@ -55,6 +55,8 @@ SSE =                # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -76,6 +78,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -fdefault-real-4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -fdefault-real-8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -90,7 +99,7 @@ FPPFLAGS += $(shell nf-config --fflags)
 FPPFLAGS += $(shell pkg-config --cflags-only-I mpich2)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS := -fcray-pointer -fdefault-double-8 $(REAL_PRECISION) -Waliasing -ffree-line-length-none -fno-range-check
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3

--- a/templates/linux-intel.mk
+++ b/templates/linux-intel.mk
@@ -79,10 +79,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/linux-intel.mk
+++ b/templates/linux-intel.mk
@@ -55,6 +55,8 @@ SSE = -xsse2         # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -76,6 +78,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -90,7 +99,7 @@ FFPPLAGS += $(shell nf-config --fflags)
 FFPPLAGS += $(shell pkg-config --cflags-only-I mpich2-c)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -stack_temps -safe_cray_ptr -ftz -assume byterecl -i4 -r8 -nowarn -g -sox -traceback
+FFLAGS := -fno-alias -stack_temps -safe_cray_ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -g -sox -traceback
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O2

--- a/templates/linux-ubuntu-trusty-gnu.mk
+++ b/templates/linux-ubuntu-trusty-gnu.mk
@@ -54,6 +54,8 @@ SSE =                # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -75,6 +77,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -fdefault-real-4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -fdefault-real-8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -87,7 +96,7 @@ FPPFLAGS := $(INCLUDES)
 FPPFLAGS += $(shell nc-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS := -fcray-pointer -fdefault-double-8 $(REAL_PRECISION) -Waliasing -ffree-line-length-none -fno-range-check
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3

--- a/templates/linux-ubuntu-xenial-gnu.mk
+++ b/templates/linux-ubuntu-xenial-gnu.mk
@@ -54,6 +54,8 @@ SSE =                # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -75,6 +77,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -fdefault-real-4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -fdefault-real-8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -87,7 +96,7 @@ FPPFLAGS := $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS := -fcray-pointer -fdefault-double-8 $(REAL_PRECISION) -Waliasing -ffree-line-length-none -fno-range-check
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3

--- a/templates/macOS-gnu8-mpich3.mk
+++ b/templates/macOS-gnu8-mpich3.mk
@@ -60,6 +60,8 @@ SSE =                # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -81,6 +83,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -fdefault-real-4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -fdefault-real-8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -98,7 +107,7 @@ FPPFLAGS += $(shell nf-config --fflags)
 FPPFLAGS += $(shell pkg-config --cflags-only-I mpich)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS := -fcray-pointer -fdefault-double-8 $(REAL_PRECISION) -Waliasing -ffree-line-length-none -fno-range-check
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3

--- a/templates/nccs-intel.mk
+++ b/templates/nccs-intel.mk
@@ -79,10 +79,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/nccs-intel.mk
+++ b/templates/nccs-intel.mk
@@ -55,6 +55,8 @@ SSE = -march=core-avx2  # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -76,6 +78,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -88,7 +97,7 @@ FPPFLAGS = -fpp -Wp,-w $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -sox -traceback
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3 -debug minimal -fp-model source

--- a/templates/ncrc-nvhpc.mk
+++ b/templates/ncrc-nvhpc.mk
@@ -48,6 +48,8 @@ INCLUDES := $(shell pkg-config --cflags yaml-0.1)
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -67,6 +69,13 @@ else ifdef DEBUG
 ifneq ($(TEST),)
 $(error Options DEBUG and TEST cannot be used together)
 endif
+endif
+
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
 endif
 
 # Check version of PGI for use of -nofma option
@@ -89,7 +98,7 @@ FPPFLAGS := $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS = -i4 -r8 -byteswapio -Mcray=pointer -Mcray=pointer -Mflushz -Mdaz -D_F2000
+FFLAGS = -i4 $(REAL_PRECISION) -byteswapio -Mcray=pointer -Mcray=pointer -Mflushz -Mdaz -D_F2000
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3 -Mvect=nosse -Mnoscalarsse -Mallocatable=95

--- a/templates/ncrc5-cce.mk
+++ b/templates/ncrc5-cce.mk
@@ -48,6 +48,8 @@ INCLUDES := $(shell pkg-config --cflags yaml-0.1)
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -69,6 +71,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := real32
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := real64
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -81,7 +90,7 @@ FPPFLAGS := $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS = -s real64 -s integer32 -h byteswapio -e m -h keepfiles -e0 -ez -N1023
+FFLAGS = -s $(REAL_PRECISION) -s integer32 -h byteswapio -e m -h keepfiles -e0 -ez -N1023
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3 -O fp2 -G2

--- a/templates/ncrc5-gcc.mk
+++ b/templates/ncrc5-gcc.mk
@@ -48,6 +48,8 @@ INCLUDES := $(shell pkg-config --cflags yaml-0.1)
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -69,6 +71,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -fdefault-real-4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -fdefault-real-8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -81,7 +90,7 @@ FPPFLAGS := $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fcray-pointer -fdefault-real-8 -fdefault-double-8 -Waliasing -ffree-line-length-none -fno-range-check -fallow-argument-mismatch
+FFLAGS := -fcray-pointer $(REAL_PRECISION) -fdefault-double-8 -Waliasing -ffree-line-length-none -fno-range-check -fallow-argument-mismatch
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O2 -fno-expensive-optimizations

--- a/templates/ncrc5-intel-classic.mk
+++ b/templates/ncrc5-intel-classic.mk
@@ -56,6 +56,8 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -77,6 +79,14 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -89,7 +99,7 @@ FPPFLAGS := -fpp -Wp,-w $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -sox -traceback
 
 # Set the ISA (vectorization) as user defined or based on the target
 ifdef ISA

--- a/templates/ncrc5-intel-classic.mk
+++ b/templates/ncrc5-intel-classic.mk
@@ -81,10 +81,10 @@ endif
 
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/ncrc5-intel-oneapi.mk
+++ b/templates/ncrc5-intel-oneapi.mk
@@ -80,10 +80,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/ncrc5-intel-oneapi.mk
+++ b/templates/ncrc5-intel-oneapi.mk
@@ -56,6 +56,8 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -77,6 +79,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -89,7 +98,7 @@ FPPFLAGS := -fpp -Wp,-w $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -traceback
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -traceback
 
 # Set the ISA (vectorization) as user defined or based on the target
 ifdef ISA

--- a/templates/ncrc5-intel.mk
+++ b/templates/ncrc5-intel.mk
@@ -80,10 +80,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Required Preprocessor Macros:

--- a/templates/ncrc5-intel.mk
+++ b/templates/ncrc5-intel.mk
@@ -56,6 +56,8 @@ ISA =
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -77,6 +79,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -89,7 +98,7 @@ FPPFLAGS := -fpp -Wp,-w $(INCLUDES)
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback -qno-opt-dynamic-align
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -sox -traceback -qno-opt-dynamic-align
 
 # Set the ISA (vectorization) as user defined or based on the target
 ifdef ISA

--- a/templates/osx-gnu.mk
+++ b/templates/osx-gnu.mk
@@ -55,6 +55,8 @@ SSE =                # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -76,6 +78,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -fdefault-double-4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -fdefault-double-8
+endif
+
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
 
@@ -93,7 +102,7 @@ endif
 FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
-FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS := -fcray-pointer -fdefault-double-8 $(REAL_PRECISION) -Waliasing -ffree-line-length-none -fno-range-check
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3

--- a/templates/theia-intel.mk
+++ b/templates/theia-intel.mk
@@ -55,6 +55,8 @@ SSE =                # The SSE options to be used to compile.  If blank,
 
 COVERAGE =           # Add the code coverage compile options.
 
+USE_R4 =             # If non-blank, use R4 for reals
+
 # Need to use at least GNU Make version 3.81
 need := 3.81
 ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
@@ -76,6 +78,13 @@ $(error Options DEBUG and TEST cannot be used together)
 endif
 endif
 
+ifdef USE_R4
+REAL_PRECISION := -r4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -r8
+endif
+
 # Macro for Fortran preprocessor
 FPPFLAGS = -fpp -Wp,-w $(INCLUDES)
 # Fortran Compiler flags for the NetCDF library
@@ -86,7 +95,7 @@ FPPFLAGS += $(shell nf-config --fflags)
 FPPFLAGS += -I$(HDF5)/include
 
 # Base set of Fortran compiler flags
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback
+FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 $(REAL_PRECISION) -nowarn -sox -traceback
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O3 -debug minimal -fp-model source

--- a/templates/theia-intel.mk
+++ b/templates/theia-intel.mk
@@ -79,10 +79,10 @@ endif
 endif
 
 ifdef USE_R4
-REAL_PRECISION := -r4
+REAL_PRECISION := -real-size 32
 CPPDEFS += -DOVERLOAD_R4
 else
-REAL_PRECISION := -r8
+REAL_PRECISION := -real-size 64
 endif
 
 # Macro for Fortran preprocessor

--- a/templates/triton-gnu.mk
+++ b/templates/triton-gnu.mk
@@ -14,6 +14,14 @@ DEBUG =
 REPRO =
 VERBOSE =
 OPENMP =
+USE_R4 =             # If non-blank, use R4 for reals
+
+ifdef USE_R4
+REAL_PRECISION := -fdefault-double-4
+CPPDEFS += -DOVERLOAD_R4
+else
+REAL_PRECISION := -fdefault-double-8
+endif
 
 # Required Preprocessor Macros:
 CPPDEFS += -Duse_netCDF
@@ -23,7 +31,7 @@ CPPDEFS += -DHAVE_SCHED_GETAFFINITY
 
 FPPFLAGS :=
 
-FFLAGS :=-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS :=-fcray-pointer -fdefault-double-8 $(REAL_PRECISION) -Waliasing -ffree-line-length-none -fno-range-check
 FFLAGS += -I/usr/include
 FFLAGS += -I$(shell nf-config --includedir)
 FFLAGS += -DGFORTRAN -Duse_netCDF3


### PR DESCRIPTION
This can be used in an xmls by doing 
```
<makeOverrides>USE_R4="ON"</makeOverrides>
```

For the component that you want to use r4 for. 

This option will allow us to compile different components at different precisions (i.e compile fv3 in r4 and everything else in r8)